### PR TITLE
chore: use alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM ubuntu:16.04
-RUN apt-get update && \
-    apt-get -y --no-install-recommends install libxml2-utils && \
-    apt-get autoremove -y && \
-    apt-get clean
+FROM alpine:latest
+RUN apk add --no-cache libxml2-utils
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Getting rid of the old ubuntu:16.04 I thought it would be nice to just use a smaller image 

Test run pending in https://github.com/nextcloud/tables/actions/runs/5130070136/jobs/9228389585?pr=336