### PR TITLE
Pull alpine base image from ecr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM public.ecr.aws/docker/library/alpine:latest
 RUN apk add --no-cache libxml2-utils
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Prevent being rate limited by docker.io. The public ECR registry mirrors/caches images directly from docker.io but has relaxed rate limiting.

Ref https://github.com/alpinelinux/docker-alpine/issues/116#issuecomment-1470803510